### PR TITLE
Use relative path to test Parson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# lh-parson 
+# lh-parson
 
-This project attempts aims to apply the libhandler model of effects and handlers to parson, a robust JSON library written in C. 
+This project attempts aims to apply the libhandler model of effects and handlers to parson, a robust JSON library written in C.
 
 Parson: https://github.com/kgabis/parson
 
@@ -9,7 +9,7 @@ libhandler:  https://github.com/koka-lang/libhandler
 # Working With this Library
 
 ## Requirements
-If you wish to contribute or otherwise experiment with this library directly, you can use the existing project structure provided you have the following pre-requisites installed: 
+If you wish to contribute or otherwise experiment with this library directly, you can use the existing project structure provided you have the following pre-requisites installed:
 
 * Python installed
 * Conan package manager installed from PIP
@@ -18,11 +18,10 @@ If you wish to contribute or otherwise experiment with this library directly, yo
 
 If you do not wish to use this particular combination of tools, you must setup your own solution to using the projects together. One common approach is to use git-submodules and CMake with custom scripting.   
 
-If these requirements prevent you from running this example, apologies.  Hopefully the library and example are trivial enough for you to use your preferred toolset. 
+If these requirements prevent you from running this example, apologies.  Hopefully the library and example are trivial enough for you to use your preferred toolset.
 
 ## Build Instructions
 1. Clone this repository
-1. Run cmake (run the following commands from the cloned directory):
-	`mkdir build && cd build && cmake .. && cmake --build .`
-1. Find and run the generated executable `libhandler-example` in the subdirectories
-
+2. Run cmake (run the following commands from the cloned directory):
+	`mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build .`
+3. Run `bin/lh_parson_test`

--- a/lh_parson_test.c
+++ b/lh_parson_test.c
@@ -70,7 +70,7 @@ int main() {
   /* serialization_example(); */
   /* persistence_example(); */
   json_set_allocation_functions(counted_malloc, counted_free);
-  //test_suite_1_lh(); 
+  //test_suite_1_lh();
   test_suite_1();
   test_suite_2_no_comments();
   test_suite_2_with_comments();
@@ -88,31 +88,31 @@ int main() {
 }
 void test_suite_1_lh(void) {
   //JSON_Value *val;
-  //TEST((json_parse_file_exn("tests/test_1_1.txt")) != NULL);
-  //TEST((json_parse_file_exn("tests/test_1_1.txt")) != NULL);
+  //TEST((json_parse_file_exn("../tests/test_1_1.txt")) != NULL);
+  //TEST((json_parse_file_exn("../tests/test_1_1.txt")) != NULL);
 
-  //TEST((val = json_parse_file("tests/test_1_1.txt")) != NULL);
+  //TEST((val = json_parse_file("../tests/test_1_1.txt")) != NULL);
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   //if (val) { json_value_free(val); }
 
-  //TEST((val = json_parse_file("tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
+  //TEST((val = json_parse_file("../tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
   //if (val) { json_value_free(val); }
 
-  //TEST((val = json_parse_file("tests/test_1_3.txt")) != NULL);
+  //TEST((val = json_parse_file("../tests/test_1_3.txt")) != NULL);
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   //if (val) { json_value_free(val); }
 
-  //TEST((val = json_parse_file_with_comments("tests/test_1_1.txt")) != NULL);
+  //TEST((val = json_parse_file_with_comments("../tests/test_1_1.txt")) != NULL);
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   //if (val) { json_value_free(val); }
 
-  //TEST((val = json_parse_file_with_comments("tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
+  //TEST((val = json_parse_file_with_comments("../tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
   //if (val) { json_value_free(val); }
 
-  //TEST((val = json_parse_file_with_comments("tests/test_1_3.txt")) != NULL);
+  //TEST((val = json_parse_file_with_comments("../tests/test_1_3.txt")) != NULL);
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   //TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   //if (val) { json_value_free(val); }
@@ -121,28 +121,28 @@ void test_suite_1_lh(void) {
 
 void test_suite_1(void) {
   JSON_Value *val;
-  TEST((val = json_parse_file("tests/test_1_1.txt")) != NULL);
+  TEST((val = json_parse_file("../tests/test_1_1.txt")) != NULL);
   TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   if (val) { json_value_free(val); }
 
-  TEST((val = json_parse_file("tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
+  TEST((val = json_parse_file("../tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
   if (val) { json_value_free(val); }
 
-  TEST((val = json_parse_file("tests/test_1_3.txt")) != NULL);
+  TEST((val = json_parse_file("../tests/test_1_3.txt")) != NULL);
   TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   if (val) { json_value_free(val); }
 
-  TEST((val = json_parse_file_with_comments("tests/test_1_1.txt")) != NULL);
+  TEST((val = json_parse_file_with_comments("../tests/test_1_1.txt")) != NULL);
   TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   if (val) { json_value_free(val); }
 
-  TEST((val = json_parse_file_with_comments("tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
+  TEST((val = json_parse_file_with_comments("../tests/test_1_2.txt")) == NULL); /* Over 2048 levels of nesting */
   if (val) { json_value_free(val); }
 
-  TEST((val = json_parse_file_with_comments("tests/test_1_3.txt")) != NULL);
+  TEST((val = json_parse_file_with_comments("../tests/test_1_3.txt")) != NULL);
   TEST(json_value_equals(json_parse_string(json_serialize_to_string(val)), val));
   TEST(json_value_equals(json_parse_string(json_serialize_to_string_pretty(val)), val));
   if (val) { json_value_free(val); }
@@ -256,7 +256,7 @@ void test_suite_2(JSON_Value *root_value) {
 }
 
 void test_suite_2_no_comments(void) {
-  const char *filename = "tests/test_2.txt";
+  const char *filename = "../tests/test_2.txt";
   JSON_Value *root_value = NULL;
   root_value = json_parse_file(filename);
   test_suite_2(root_value);
@@ -266,7 +266,7 @@ void test_suite_2_no_comments(void) {
 }
 
 void test_suite_2_with_comments(void) {
-  const char *filename = "tests/test_2_comments.txt";
+  const char *filename = "../tests/test_2_comments.txt";
   JSON_Value *root_value = NULL;
   root_value = json_parse_file_with_comments(filename);
   test_suite_2(root_value);
@@ -341,7 +341,7 @@ void test_suite_3(void) {
 }
 
 void test_suite_4() {
-  const char *filename = "tests/test_2.txt";
+  const char *filename = "../tests/test_2.txt";
   JSON_Value *a = NULL, *a_copy = NULL;
   printf("Testing %s:\n", filename);
   a = json_parse_file(filename);
@@ -352,7 +352,7 @@ void test_suite_4() {
 }
 
 void test_suite_5(void) {
-  JSON_Value *val_from_file = json_parse_file("tests/test_5.txt");
+  JSON_Value *val_from_file = json_parse_file("../tests/test_5.txt");
 
   JSON_Value *val = NULL, *val_parent;
   JSON_Object *obj = NULL;
@@ -479,7 +479,7 @@ void test_suite_5(void) {
 }
 
 void test_suite_6(void) {
-  const char *filename = "tests/test_2.txt";
+  const char *filename = "../tests/test_2.txt";
   JSON_Value *a = NULL;
   JSON_Value *b = NULL;
   a = json_parse_file(filename);
@@ -494,7 +494,7 @@ void test_suite_6(void) {
 }
 
 void test_suite_7(void) {
-  JSON_Value *val_from_file = json_parse_file("tests/test_5.txt");
+  JSON_Value *val_from_file = json_parse_file("../tests/test_5.txt");
   JSON_Value *schema = json_value_init_object();
   JSON_Object *schema_obj = json_value_get_object(schema);
   JSON_Array *interests_arr = NULL;
@@ -511,8 +511,8 @@ void test_suite_7(void) {
 }
 
 void test_suite_8(void) {
-  const char *filename = "tests/test_2.txt";
-  const char *temp_filename = "tests/test_2_serialized.txt";
+  const char *filename = "../tests/test_2.txt";
+  const char *temp_filename = "../tests/test_2_serialized.txt";
   JSON_Value *a = NULL;
   JSON_Value *b = NULL;
   char *buf = NULL;
@@ -528,8 +528,8 @@ void test_suite_8(void) {
 }
 
 void test_suite_9(void) {
-  const char *filename = "tests/test_2_pretty.txt";
-  const char *temp_filename = "tests/test_2_serialized_pretty.txt";
+  const char *filename = "../tests/test_2_pretty.txt";
+  const char *temp_filename = "../tests/test_2_serialized_pretty.txt";
   char *file_contents = NULL;
   char *serialized = NULL;
   JSON_Value *a = NULL;
@@ -555,18 +555,18 @@ void test_suite_10(void) {
 
   malloc_count = 0;
 
-  val = json_parse_file("tests/test_1_1.txt");
+  val = json_parse_file("../tests/test_1_1.txt");
   json_value_free(val);
 
-  val = json_parse_file("tests/test_1_3.txt");
+  val = json_parse_file("../tests/test_1_3.txt");
   json_value_free(val);
 
-  val = json_parse_file("tests/test_2.txt");
+  val = json_parse_file("../tests/test_2.txt");
   serialized = json_serialize_to_string_pretty(val);
   json_free_serialized_string(serialized);
   json_value_free(val);
 
-  val = json_parse_file("tests/test_2_pretty.txt");
+  val = json_parse_file("../tests/test_2_pretty.txt");
   json_value_free(val);
 
   TEST(malloc_count == 0);


### PR DESCRIPTION
All Parson tests use test/ dir to load it JSON files, however,  the test expect that these files are in same directory. When we use conan + cmake to build the project, the test/ will be placed two levels above from build/bin, so it's not possible to find the JSON files.

There are some workarounds to fix this point:

- Change the test code to search all JSON files. More complicated to be implemented using only C. You need the walk through the directories to find some JSON file.

- Use hardcoded relative path on code. Very simple, but forces the developer to use a singular directory to execute all tests. It only works when you are at build/ and execute bin/lh_parson_test

- Fill test directory by variable. Add some options based on env vars or argument to fill test/ path. Again, complicated to be implemented, need to parse arguments and fill all paths in runtime.

- This PR uses the second choice, the developer MUST be in build/ to execute all tests, otherwise, a segfault will be thrown by test as you saw before.

Also, I changed your README file to execute all expected steps, including add CMAKE_BUILD_TYPE, required by conan.cmake.

Regards.